### PR TITLE
Relax dependency version constraints

### DIFF
--- a/packages/type-r-t2i/pyproject.toml
+++ b/packages/type-r-t2i/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "requests>=2.32.3",
     "torch>=2.1.2",
     "accelerate>=0.34.2",
-    "google-genai>=1.19.0",
+    "google-genai>=1.0.0",
 ]
 
 [build-system]

--- a/patch/DeepSolo.patch
+++ b/patch/DeepSolo.patch
@@ -142,7 +142,7 @@ index 0000000..3bd1718
 +    "editdistance",
 +    "opencv-python",
 +    "detectron2",
-+    "protobuf==3.20.*",
++    "protobuf>=3.20",
 +]
 +
 +[project.urls]

--- a/patch/DeepSolo.patch
+++ b/patch/DeepSolo.patch
@@ -142,7 +142,7 @@ index 0000000..3bd1718
 +    "editdistance",
 +    "opencv-python",
 +    "detectron2",
-+    "protobuf>=3.20",
++    "protobuf>=3.20,<4.0",
 +]
 +
 +[project.urls]


### PR DESCRIPTION
Changes:
- Specify broader `google-genai` package versions
- Allow newer `protobuf` packages